### PR TITLE
chore: use bun instead of npx to apply biome checks in `lefthook.yml`

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
     check:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
       tags: biome
-      run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: bun run biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
 
     check-lockfile:


### PR DESCRIPTION
fix #18 